### PR TITLE
Adding AWS SSO service access

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -6,3 +6,8 @@ variable "already_exists" {
   default     = false
   description = "Whether the organization already exists or needs to be created"
 }
+
+variable "enable_aws_sso" {
+  default     = false
+  description = "Whether the AWS SSO needs to be enabled when creating a new organisation"
+}

--- a/organization.tf
+++ b/organization.tf
@@ -4,6 +4,7 @@ resource "aws_organizations_organization" "org" {
   aws_service_access_principals = [
     "cloudtrail.amazonaws.com",
     "config.amazonaws.com",
+    var.enable_aws_sso ? "sso.amazonaws.com" : "",
   ]
 
   enabled_policy_types = ["SERVICE_CONTROL_POLICY"]


### PR DESCRIPTION
Add option to enable AWS SSO service principal when creating a new organisation

## Types of changes

What types of changes does your code introduce to `terraform-aws-organization` repository?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added the necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

When the organisation is created via this module the org policy is also managed by terraform. Therefore it is necessary to add the AWS SSO AWS service principal which enables integration with the service. Hence, it avoids state drift when using AWS SSO service. Apart from this, there will be no changes when `already_exists ` parameter is set to true because the organisation policy would not be managed by terraform.